### PR TITLE
Processmanager

### DIFF
--- a/windows/handles.go
+++ b/windows/handles.go
@@ -16,6 +16,7 @@ type Handle struct {
 	RegKey            *RegKey
 	Thread            *Thread
 	ResourceDataEntry *pefile.ResourceDataEntry
+	Snapshot          *Snapshot
 }
 
 func (handle *Handle) Close() {

--- a/windows/hooks.go
+++ b/windows/hooks.go
@@ -48,6 +48,7 @@ func (emu *WinEmulator) LoadHooks() {
 	UtilapiHooks(emu)
 	ShlobjCoreHooks(emu)
 	MemoryApiHooks(emu)
+	ToolHelpHooks(emu)
 }
 func (emu *WinEmulator) SetupHooks() error {
 	emu.Uc.HookAdd(uc.HOOK_CODE, HookCode(emu), 1, 0)

--- a/windows/processmanager.go
+++ b/windows/processmanager.go
@@ -1,0 +1,833 @@
+package windows
+
+import (
+	"fmt"
+	"math"
+	"unsafe"
+)
+
+type ProcessManager struct {
+	numberOfProcesses uint64
+	processList       []Process
+}
+type Process struct {
+	dwSize              uint32
+	cntUsage            uint32
+	the32ProcessID      uint32
+	th32DefaultHeapID   uint32
+	th32ModuleID        uint32
+	cntThreads          uint32
+	th32ParentProcessID uint32
+	pcPriClassBase      int32
+	dwFlags             uint32
+	szExeFile           [260]byte
+	//Other features might be added
+}
+
+func InitializeProcessManager(addStub bool) *ProcessManager {
+	newProcessManager := &ProcessManager{numberOfProcesses: 0}
+	if addStub {
+		newProcessManager.addStubProcesses()
+	}
+	return newProcessManager
+}
+
+func (p *ProcessManager) addStubProcesses() {
+	stub := make(map[string]interface{})
+	//This data is extracted from a windows 10-64bit os.
+	stub["szExeFile"] = "r3billions"
+	p.startProcess(stub)
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "[System Process]"
+	stub["cntThreads"] = uint32(0)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(0)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "System"
+	stub["cntThreads"] = uint32(4)
+	stub["th32ParentProcessID"] = uint32(118)
+	stub["pcPriClassBase"] = int32(0)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "Registry"
+	stub["cntThreads"] = uint32(88)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(4)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "smss.exe"
+	stub["cntThreads"] = uint32(352)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(4)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "csrss.exe"
+	stub["cntThreads"] = uint32(468)
+	stub["th32ParentProcessID"] = uint32(10)
+	stub["pcPriClassBase"] = int32(456)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "csrss.exe"
+	stub["cntThreads"] = uint32(548)
+	stub["th32ParentProcessID"] = uint32(11)
+	stub["pcPriClassBase"] = int32(540)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "wininit.exe"
+	stub["cntThreads"] = uint32(556)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(456)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "winlogon.exe"
+	stub["cntThreads"] = uint32(624)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(540)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "services.exe"
+	stub["cntThreads"] = uint32(688)
+	stub["th32ParentProcessID"] = uint32(9)
+	stub["pcPriClassBase"] = int32(556)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "lsass.exe"
+	stub["cntThreads"] = uint32(704)
+	stub["th32ParentProcessID"] = uint32(8)
+	stub["pcPriClassBase"] = int32(556)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(808)
+	stub["th32ParentProcessID"] = uint32(19)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "fontdrvhost.exe"
+	stub["cntThreads"] = uint32(848)
+	stub["th32ParentProcessID"] = uint32(5)
+	stub["pcPriClassBase"] = int32(624)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "fontdrvhost.exe"
+	stub["cntThreads"] = uint32(844)
+	stub["th32ParentProcessID"] = uint32(5)
+	stub["pcPriClassBase"] = int32(556)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "WUDFHost.exe"
+	stub["cntThreads"] = uint32(872)
+	stub["th32ParentProcessID"] = uint32(8)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(980)
+	stub["th32ParentProcessID"] = uint32(12)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "dwm.exe"
+	stub["cntThreads"] = uint32(420)
+	stub["th32ParentProcessID"] = uint32(13)
+	stub["pcPriClassBase"] = int32(624)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "WUDFHost.exe"
+	stub["cntThreads"] = uint32(432)
+	stub["th32ParentProcessID"] = uint32(8)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(308)
+	stub["th32ParentProcessID"] = uint32(9)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1036)
+	stub["th32ParentProcessID"] = uint32(16)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1072)
+	stub["th32ParentProcessID"] = uint32(17)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1240)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1300)
+	stub["th32ParentProcessID"] = uint32(25)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1344)
+	stub["th32ParentProcessID"] = uint32(58)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1460)
+	stub["th32ParentProcessID"] = uint32(21)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "Memory Compression"
+	stub["cntThreads"] = uint32(1476)
+	stub["th32ParentProcessID"] = uint32(62)
+	stub["pcPriClassBase"] = int32(4)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1624)
+	stub["th32ParentProcessID"] = uint32(10)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1708)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1716)
+	stub["th32ParentProcessID"] = uint32(6)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "spoolsv.exe"
+	stub["cntThreads"] = uint32(1832)
+	stub["th32ParentProcessID"] = uint32(7)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1868)
+	stub["th32ParentProcessID"] = uint32(12)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1940)
+	stub["th32ParentProcessID"] = uint32(16)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(2004)
+	stub["th32ParentProcessID"] = uint32(15)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1528)
+	stub["th32ParentProcessID"] = uint32(16)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1488)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(2124)
+	stub["th32ParentProcessID"] = uint32(12)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "dllhost.exe"
+	stub["cntThreads"] = uint32(2232)
+	stub["th32ParentProcessID"] = uint32(5)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "PresentationFontCache.exe"
+	stub["cntThreads"] = uint32(2240)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "coherence.exe"
+	stub["cntThreads"] = uint32(2264)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "sqlwriter.exe"
+	stub["cntThreads"] = uint32(2276)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "MsMpEng.exe"
+	stub["cntThreads"] = uint32(2288)
+	stub["th32ParentProcessID"] = uint32(25)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "prl_tools_service.exe"
+	stub["cntThreads"] = uint32(2300)
+	stub["th32ParentProcessID"] = uint32(7)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "dasHost.exe"
+	stub["cntThreads"] = uint32(2496)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(1072)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "prl_tools.exe"
+	stub["cntThreads"] = uint32(2552)
+	stub["th32ParentProcessID"] = uint32(9)
+	stub["pcPriClassBase"] = int32(2300)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "dllhost.exe"
+	stub["cntThreads"] = uint32(2784)
+	stub["th32ParentProcessID"] = uint32(10)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "msdtc.exe"
+	stub["cntThreads"] = uint32(2880)
+	stub["th32ParentProcessID"] = uint32(9)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "coherence.exe"
+	stub["cntThreads"] = uint32(2536)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(2264)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "coherence.exe"
+	stub["cntThreads"] = uint32(3828)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(2536)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "sihost.exe"
+	stub["cntThreads"] = uint32(4476)
+	stub["th32ParentProcessID"] = uint32(11)
+	stub["pcPriClassBase"] = int32(1344)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(4512)
+	stub["th32ParentProcessID"] = uint32(13)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "taskhostw.exe"
+	stub["cntThreads"] = uint32(4612)
+	stub["th32ParentProcessID"] = uint32(9)
+	stub["pcPriClassBase"] = int32(1344)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "explorer.exe"
+	stub["cntThreads"] = uint32(4940)
+	stub["th32ParentProcessID"] = uint32(62)
+	stub["pcPriClassBase"] = int32(4912)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(5072)
+	stub["th32ParentProcessID"] = uint32(12)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "StartMenuExperienceHost.exe"
+	stub["cntThreads"] = uint32(5180)
+	stub["th32ParentProcessID"] = uint32(16)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(5280)
+	stub["th32ParentProcessID"] = uint32(5)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SearchUI.exe"
+	stub["cntThreads"] = uint32(5380)
+	stub["th32ParentProcessID"] = uint32(43)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SearchIndexer.exe"
+	stub["cntThreads"] = uint32(5400)
+	stub["th32ParentProcessID"] = uint32(19)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(5520)
+	stub["th32ParentProcessID"] = uint32(14)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SkypeApp.exe"
+	stub["cntThreads"] = uint32(5960)
+	stub["th32ParentProcessID"] = uint32(15)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SkypeBackgroundHost.exe"
+	stub["cntThreads"] = uint32(5968)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "ApplicationFrameHost.exe"
+	stub["cntThreads"] = uint32(5988)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "MicrosoftEdge.exe"
+	stub["cntThreads"] = uint32(6032)
+	stub["th32ParentProcessID"] = uint32(25)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "YourPhone.exe"
+	stub["cntThreads"] = uint32(6072)
+	stub["th32ParentProcessID"] = uint32(16)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "browser_broker.exe"
+	stub["cntThreads"] = uint32(6180)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(6188)
+	stub["th32ParentProcessID"] = uint32(1)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "MicrosoftEdgeSH.exe"
+	stub["cntThreads"] = uint32(6372)
+	stub["th32ParentProcessID"] = uint32(9)
+	stub["pcPriClassBase"] = int32(6188)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "MicrosoftEdgeCP.exe"
+	stub["cntThreads"] = uint32(6416)
+	stub["th32ParentProcessID"] = uint32(16)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "prl_cc.exe"
+	stub["cntThreads"] = uint32(6640)
+	stub["th32ParentProcessID"] = uint32(31)
+	stub["pcPriClassBase"] = int32(2552)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "ctfmon.exe"
+	stub["cntThreads"] = uint32(6680)
+	stub["th32ParentProcessID"] = uint32(8)
+	stub["pcPriClassBase"] = int32(1072)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "TabTip.exe"
+	stub["cntThreads"] = uint32(6704)
+	stub["th32ParentProcessID"] = uint32(6)
+	stub["pcPriClassBase"] = int32(1072)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "WindowsInternal.ComposableShell.Experiences.TextInput.InputApp.exe"
+	stub["cntThreads"] = uint32(7116)
+	stub["th32ParentProcessID"] = uint32(11)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(7320)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SecurityHealthSystray.exe"
+	stub["cntThreads"] = uint32(7420)
+	stub["th32ParentProcessID"] = uint32(1)
+	stub["pcPriClassBase"] = int32(4940)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SecurityHealthService.exe"
+	stub["cntThreads"] = uint32(7448)
+	stub["th32ParentProcessID"] = uint32(7)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(7540)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "OneDrive.exe"
+	stub["cntThreads"] = uint32(7580)
+	stub["th32ParentProcessID"] = uint32(26)
+	stub["pcPriClassBase"] = int32(4940)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "jusched.exe"
+	stub["cntThreads"] = uint32(7960)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(7596)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(8036)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SecurityHealthHost.exe"
+	stub["cntThreads"] = uint32(3020)
+	stub["th32ParentProcessID"] = uint32(1)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "ShellExperienceHost.exe"
+	stub["cntThreads"] = uint32(5032)
+	stub["th32ParentProcessID"] = uint32(14)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(4164)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SgrmBroker.exe"
+	stub["cntThreads"] = uint32(4964)
+	stub["th32ParentProcessID"] = uint32(5)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(7900)
+	stub["th32ParentProcessID"] = uint32(8)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "WinStore.App.exe"
+	stub["cntThreads"] = uint32(5288)
+	stub["th32ParentProcessID"] = uint32(16)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(820)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "jucheck.exe"
+	stub["cntThreads"] = uint32(7176)
+	stub["th32ParentProcessID"] = uint32(5)
+	stub["pcPriClassBase"] = int32(7960)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(1332)
+	stub["th32ParentProcessID"] = uint32(3)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "Video.UI.exe"
+	stub["cntThreads"] = uint32(1324)
+	stub["th32ParentProcessID"] = uint32(18)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(5008)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "dllhost.exe"
+	stub["cntThreads"] = uint32(6140)
+	stub["th32ParentProcessID"] = uint32(6)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "taskhostw.exe"
+	stub["cntThreads"] = uint32(5044)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(1344)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "Microsoft.Photos.exe"
+	stub["cntThreads"] = uint32(8084)
+	stub["th32ParentProcessID"] = uint32(14)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(7872)
+	stub["th32ParentProcessID"] = uint32(9)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "cmd.exe"
+	stub["cntThreads"] = uint32(2856)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(4940)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "conhost.exe"
+	stub["cntThreads"] = uint32(8912)
+	stub["th32ParentProcessID"] = uint32(5)
+	stub["pcPriClassBase"] = int32(2856)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SearchProtocolHost.exe"
+	stub["cntThreads"] = uint32(4236)
+	stub["th32ParentProcessID"] = uint32(7)
+	stub["pcPriClassBase"] = int32(5400)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "SearchFilterHost.exe"
+	stub["cntThreads"] = uint32(8636)
+	stub["th32ParentProcessID"] = uint32(5)
+	stub["pcPriClassBase"] = int32(5400)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "backgroundTaskHost.exe"
+	stub["cntThreads"] = uint32(5496)
+	stub["th32ParentProcessID"] = uint32(14)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "svchost.exe"
+	stub["cntThreads"] = uint32(4664)
+	stub["th32ParentProcessID"] = uint32(4)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "RuntimeBroker.exe"
+	stub["cntThreads"] = uint32(3232)
+	stub["th32ParentProcessID"] = uint32(7)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "WmiPrvSE.exe"
+	stub["cntThreads"] = uint32(5616)
+	stub["th32ParentProcessID"] = uint32(10)
+	stub["pcPriClassBase"] = int32(808)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "NisSrv.exe"
+	stub["cntThreads"] = uint32(3220)
+	stub["th32ParentProcessID"] = uint32(7)
+	stub["pcPriClassBase"] = int32(688)
+	p.startProcess(stub)
+
+	stub = make(map[string]interface{})
+	stub["szExeFile"] = "a.exe"
+	stub["cntThreads"] = uint32(8420)
+	stub["th32ParentProcessID"] = uint32(2)
+	stub["pcPriClassBase"] = int32(2856)
+	p.startProcess(stub)
+
+}
+func (p *Process) processAsEntry() ProcessEntry {
+	return ProcessEntry{p.dwSize, p.cntUsage, p.the32ProcessID, p.th32DefaultHeapID, p.th32ModuleID,
+		p.cntThreads, p.th32ParentProcessID, p.pcPriClassBase, p.dwFlags, p.szExeFile}
+}
+
+func (p *ProcessManager) getProcessEntries() []ProcessEntry {
+	processEntries := make([]ProcessEntry, p.numberOfProcesses)
+	for i := range p.processList {
+		processEntries[i] = p.processList[i].processAsEntry()
+	}
+	return processEntries
+}
+func (p *ProcessManager) terminateProcess(index int) bool {
+	index -= 1
+	succ := false
+	if index >= 0 && uint64(index) < p.numberOfProcesses {
+		p.processList = append(p.processList[0:index], p.processList[index+1:]...)
+		p.numberOfProcesses -= 1
+		succ = true
+	}
+	return succ
+}
+func (p *ProcessManager) openProcess(processID uint32) int {
+	for i, proc := range p.processList {
+		if proc.the32ProcessID == processID {
+			return i + 1
+		}
+	}
+	return -1
+}
+func (p *ProcessManager) startProcess(parameters map[string]interface{}) bool {
+	newProcess := Process{dwSize: uint32(unsafe.Sizeof(ProcessEntry{})), cntUsage: 0, th32DefaultHeapID: 0, th32ModuleID: 0, dwFlags: 0}
+	for parameter, value := range parameters {
+		//Any new parameter should be added here with no headache of changing the function everywhere.
+		switch parameter {
+		case "dwSize":
+			newProcess.dwSize = value.(uint32)
+			continue
+		case "cntUsage":
+			newProcess.cntUsage = value.(uint32)
+			continue
+		case "the32ProcessID":
+			newProcess.the32ProcessID = value.(uint32)
+			continue
+		case "th32DefaultHeapID":
+			newProcess.th32DefaultHeapID = value.(uint32)
+			continue
+		case "th32ModuleID":
+			newProcess.th32ModuleID = value.(uint32)
+			continue
+		case "cntThreads":
+			newProcess.cntThreads = value.(uint32)
+			continue
+		case "th32ParentProcessID":
+			newProcess.th32ParentProcessID = value.(uint32)
+			continue
+		case "pcPriClassBase":
+			newProcess.pcPriClassBase = value.(int32)
+			continue
+		case "dwFlags":
+			newProcess.dwFlags = value.(uint32)
+			continue
+		case "szExeFile":
+			szExeFile := value.(string)
+			var processNameAdjusted [260]byte
+			copy(processNameAdjusted[0:259], szExeFile)
+			length := math.Min(float64(len(szExeFile)), 259)
+			processNameAdjusted[int(length)] = 0
+			newProcess.szExeFile = processNameAdjusted
+			continue
+		default:
+			fmt.Errorf("specified parameter [%s] not supported", parameter)
+		}
+
+	}
+	p.numberOfProcesses++
+	p.processList = append(p.processList, newProcess)
+	return true
+}

--- a/windows/processthreadsapi.go
+++ b/windows/processthreadsapi.go
@@ -19,6 +19,34 @@ func ProcessthreadsapiHooks(emu *WinEmulator) {
 		Parameters: []string{"hToken", "w:lpApplicationName", "w:lpCommandLine", "lpProcessAttributes", "lpThreadAttributes", "bInheritHandles", "dwCreationFlags", "lpEnvironment", "lpCurrentDirectory", "lpStartupInfo", "lpProcessInformation"},
 		Fn:         SkipFunctionStdCall(true, 0x1),
 	})
+	emu.AddHook("", "OpenProcess", &Hook{
+		Parameters: []string{"dwDesiredAccess", "bInheritHandle", "dwProcessId"},
+		Fn: func(emulator *WinEmulator, in *Instruction) bool {
+			procIndex := emu.ProcessManager.openProcess(uint32(in.Args[2]))
+			if procIndex == -1 {
+				return SkipFunctionStdCall(true, 0)(emu, in)
+			}
+			return SkipFunctionStdCall(true, uint64(procIndex))(emu, in)
+		},
+	})
+	emu.AddHook("", "TerminateProcess", &Hook{
+		Parameters: []string{"hProcess", "uExitCode"},
+		Fn: func(emulator *WinEmulator, in *Instruction) bool {
+			if in.Args[0] == 0xffffffff {
+				return false
+			}
+			success := emu.ProcessManager.terminateProcess(int(in.Args[0]))
+			if success {
+				return SkipFunctionStdCall(true, 0x1337)(emu, in)
+			} else {
+				return SkipFunctionStdCall(true, 0)(emu, in)
+			}
+		},
+	})
+	emu.AddHook("", "GetPriorityClass", &Hook{
+		Parameters: []string{"Handle"},
+		Fn:         SkipFunctionStdCall(true, 0x1337),
+	})
 
 	emu.AddHook("", "CreateThread", &Hook{
 		Parameters: []string{"lpThreadAttributes", "dwStackSize", "lpStartAddress", "lpParameter", "dwCreationFlags", "lpThreadId"},

--- a/windows/toolhelp.go
+++ b/windows/toolhelp.go
@@ -1,0 +1,179 @@
+package windows
+
+import (
+	"github.com/carbonblack/binee/util"
+	"unsafe"
+)
+
+// #define TH32CS_SNAPHEAPLIST 0x1
+// #define TH32CS_SNAPPROCESS  0x2
+// #define TH32CS_SNAPTHREAD   0x4
+// #define TH32CS_SNAPMODULE   0x8
+// #define TH32CS_SNAPALL  (TH32CS_SNAPHEAPLIST|TH32CS_SNAPPROCESS|TH32CS_SNAPTHREAD|TH32CS_SNAPMODULE)
+// #define TH32CS_INHERIT  0x80000000
+
+const (
+	Th32csSnapheaplist = 0x1
+	Th32csSnapprocess  = 0x2
+	Th32csSnapthread   = 0x4
+	Th32csSnapmodule   = 0x8
+	Th32csSnapall      = Th32csSnapheaplist | Th32csSnapprocess | Th32csSnapthread | Th32csSnapmodule
+	Th32csInherit      = 0x80000000
+)
+
+type Snapshot struct {
+	/* Heap list */
+	//ULONG HeapListCount;
+	//ULONG HeapListIndex;
+	//ULONG_PTR HeapListOffset;
+	///* Module list */
+	//ULONG ModuleListCount;
+	//ULONG ModuleListIndex;
+	//ULONG_PTR ModuleListOffset;
+	/* Process list */
+	ProcessListCount uint64
+	ProcessListIndex uint64
+	ProcessList      []ProcessEntry
+	/* Thread list */
+	//ULONG ThreadListCount;
+	//ULONG ThreadListIndex;
+	//ULONG_PTR ThreadListOffset;
+}
+type ProcessEntryW struct {
+	dwSize              uint32
+	cntUsage            uint32
+	the32ProcessID      uint32
+	th32DefaultHeapID   uint32
+	th32ModuleID        uint32
+	cntThreads          uint32
+	th32ParentProcessID uint32
+	pcPriClassBase      int32
+	dwFlags             uint32
+	szExeFile           [260 * 2]byte
+}
+type ProcessEntry struct {
+	dwSize              uint32
+	cntUsage            uint32
+	the32ProcessID      uint32
+	th32DefaultHeapID   uint32
+	th32ModuleID        uint32
+	cntThreads          uint32
+	th32ParentProcessID uint32
+	pcPriClassBase      int32
+	dwFlags             uint32
+	szExeFile           [260]byte
+}
+
+func (p ProcessEntry) toWide() *ProcessEntryW {
+	wideProcess := &ProcessEntryW{}
+	wideProcess.dwSize = uint32(unsafe.Sizeof(ProcessEntryW{}))
+	wideProcess.cntUsage = p.cntUsage
+	wideProcess.the32ProcessID = p.the32ProcessID
+	wideProcess.th32DefaultHeapID = p.th32DefaultHeapID
+	wideProcess.th32ModuleID = p.th32ModuleID
+	wideProcess.cntThreads = p.cntThreads
+	wideProcess.th32ParentProcessID = p.th32ParentProcessID
+	wideProcess.pcPriClassBase = p.pcPriClassBase
+	wideProcess.dwFlags = p.dwFlags
+	for i := 0; i < 260*2; i += 2 {
+		if p.szExeFile[i/2] == 0 {
+			wideProcess.szExeFile[i] = 0
+			wideProcess.szExeFile[i+1] = 0
+			break
+		}
+		wideProcess.szExeFile[i] = p.szExeFile[i/2]
+		wideProcess.szExeFile[i+1] = 0
+	}
+	return wideProcess
+}
+
+func createToolhelp32Snapshot(emu *WinEmulator, in *Instruction) func(emu *WinEmulator, in *Instruction) bool {
+	dwFlags := in.Args[0]
+	snapshotHandle := &Handle{
+		Snapshot: &Snapshot{ProcessListCount: 0},
+	}
+	if dwFlags&Th32csSnapprocess > 1 {
+		snapshotHandle.Snapshot.ProcessList = emu.ProcessManager.getProcessEntries()
+		snapshotHandle.Snapshot.ProcessListCount = emu.ProcessManager.numberOfProcesses
+
+	}
+	handleAddr := emu.Heap.Malloc(4)
+	emu.Handles[handleAddr] = snapshotHandle
+	return SkipFunctionStdCall(true, handleAddr)
+}
+
+func process32First(emu *WinEmulator, in *Instruction, wide bool) func(emu *WinEmulator, in *Instruction) bool {
+	if emu.Handles[in.Args[0]].Snapshot == nil {
+		return SkipFunctionStdCall(true, 0)
+	}
+	snapshot := emu.Handles[in.Args[0]].Snapshot
+	snapshot.ProcessListIndex = 1
+	returnAddress := in.Args[1]
+	var process interface{}
+	if wide {
+		process = snapshot.ProcessList[0].toWide()
+	} else {
+		process = snapshot.ProcessList[0]
+	}
+	util.StructWrite(emu.Uc, returnAddress, process)
+	return SkipFunctionStdCall(true, 1)
+}
+func process32Next(emu *WinEmulator, in *Instruction, wide bool) func(emu *WinEmulator, in *Instruction) bool {
+	if emu.Handles[in.Args[0]].Snapshot == nil {
+		return SkipFunctionStdCall(true, 0)
+	}
+	snapshot := emu.Handles[in.Args[0]].Snapshot
+	index := snapshot.ProcessListIndex
+	if index == snapshot.ProcessListCount {
+		return SkipFunctionStdCall(true, 0)
+	}
+	returnAddress := in.Args[1]
+	var process interface{}
+	if wide {
+		process = snapshot.ProcessList[index].toWide()
+	} else {
+		process = snapshot.ProcessList[index]
+	}
+	util.StructWrite(emu.Uc, returnAddress, process)
+	snapshot.ProcessListIndex++
+	return SkipFunctionStdCall(true, 1)
+}
+
+func ToolHelpHooks(emu *WinEmulator) {
+	emu.AddHook("", "CreateToolhelp32Snapshot", &Hook{
+		Parameters: []string{"dwFlags", "the32ProceessID"},
+		Fn: func(emu *WinEmulator, in *Instruction) bool {
+			return createToolhelp32Snapshot(emu, in)(emu, in)
+		},
+	})
+
+	emu.AddHook("", "Process32First", &Hook{
+		Parameters: []string{"hSnapshot", "lppe"},
+		Fn: func(emu *WinEmulator, in *Instruction) bool {
+			return process32First(emu, in, false)(emu, in)
+		},
+	})
+	emu.AddHook("", "Process32FirstW", &Hook{
+		Parameters: []string{"hSnapshot", "lppe"},
+		Fn: func(emu *WinEmulator, in *Instruction) bool {
+			return process32First(emu, in, true)(emu, in)
+		},
+	})
+	emu.AddHook("", "Process32Next", &Hook{
+		Parameters: []string{"hSnapshot", "lppe"},
+		Fn: func(emu *WinEmulator, in *Instruction) bool {
+			return process32Next(emu, in, false)(emu, in)
+		},
+	})
+	emu.AddHook("", "Process32NextW", &Hook{
+		Parameters: []string{"hSnapshot", "lppe"},
+		Fn: func(emu *WinEmulator, in *Instruction) bool {
+			return process32Next(emu, in, true)(emu, in)
+		},
+	})
+
+	emu.AddHook("", "GetTokenInformation", &Hook{
+		Parameters: []string{"TokenHandle", "TokenInformationClass", "TokenInformation", "TokenInformationLength", "ReturnLength"},
+		Fn:         SkipFunctionStdCall(true, 0),
+	})
+}

--- a/windows/ucrtbase.go
+++ b/windows/ucrtbase.go
@@ -1,13 +1,49 @@
 package windows
 
 import (
+	"github.com/unicorn-engine/unicorn/bindings/go/unicorn"
 	"strconv"
 	"time"
 
 	"github.com/carbonblack/binee/util"
 )
 
-//import "fmt"
+func sprintf(emu *WinEmulator, in *Instruction, wide bool) {
+	var format string
+	if wide {
+		format = util.ReadWideChar(emu.Uc, in.Args[0], 0)
+	} else {
+		format = util.ReadASCII(emu.Uc, in.Args[0], 0)
+	}
+	parameters := util.ParseFormatter(format)
+	var startAddr uint64
+	//Get stack address
+	if emu.PtrSize == 4 {
+		startAddr, _ = emu.Uc.RegRead(unicorn.X86_REG_ESP)
+	} else {
+		startAddr, _ = emu.Uc.RegRead(unicorn.X86_REG_ESP)
+	}
+	//Jump 2 entries
+	startAddr += 2 * emu.PtrSize
+	in.VaArgsParse(startAddr, len(parameters))
+	in.FmtToParameters(parameters)
+}
+func printf(emu *WinEmulator, in *Instruction) bool {
+	format := util.ReadASCII(emu.Uc, in.Args[0], 0)
+	parameters := util.ParseFormatter(format)
+	var startAddr uint64
+	//Get stack address
+	if emu.PtrSize == 4 {
+		startAddr, _ = emu.Uc.RegRead(unicorn.X86_REG_ESP)
+	} else {
+		startAddr, _ = emu.Uc.RegRead(unicorn.X86_REG_ESP)
+	}
+	//Jump 2 entries
+	startAddr += 2 * emu.PtrSize
+	in.VaArgsParse(startAddr, len(parameters))
+	in.FmtToParameters(parameters)
+	return SkipFunctionCdecl(false, 0)(emu, in)
+}
 
 func UcrtBase32Hooks(emu *WinEmulator) {
 	emu.AddHook("", "__acrt_iob_func", &Hook{Parameters: []string{}})
@@ -147,12 +183,26 @@ func UcrtBase32Hooks(emu *WinEmulator) {
 	emu.AddHook("", "wcsncpy", &Hook{
 		Parameters: []string{"strDest", "strSource", "count"},
 	})
+
+	emu.AddHook("", "printf", &Hook{
+		Parameters: []string{"a:format"},
+		Fn:         printf,
+	})
 	emu.AddHook("", "sprintf", &Hook{
-		Parameters: []string{"buffer", "a:format", "..."},
+		Parameters: []string{"buffer", "a:format"},
+		Fn: func(emulator *WinEmulator, in *Instruction) bool {
+			sprintf(emu, in, false)
+			return true
+		},
 	})
 	emu.AddHook("", "swprintf", &Hook{
-		Parameters: []string{"buffer", "count", "a:format", "..."},
+		Parameters: []string{"buffer", "count", "w:format"},
+		Fn: func(emulator *WinEmulator, in *Instruction) bool {
+			sprintf(emu, in, true)
+			return true
+		},
 	})
+
 	emu.AddHook("", "strcat", &Hook{
 		Parameters: []string{"a:string1", "a:string2"},
 	})

--- a/windows/winemulator.go
+++ b/windows/winemulator.go
@@ -93,6 +93,7 @@ type WinEmulator struct {
 	Fls                [64]uint64
 	Opts               WinOptions
 	ResourcesRoot      pefile.ResourceDirectory
+	ProcessManager     *ProcessManager
 	// these commands are used to keep state during single step mode
 	LastCommand  string
 	Breakpoints  map[uint64]uint64
@@ -212,6 +213,7 @@ func LoadMem(pe *pefile.PeFile, path string, args []string, options *WinEmulator
 	emu.MemRegions.ImageSize = uint64(32 * 1024 * 1024)
 	emu.Seed = 1
 	emu.ResourcesRoot = pe.ResourceDirectoryRoot
+	emu.ProcessManager = InitializeProcessManager(true)
 
 	if pe.PeType == pefile.Pe32 {
 		emu.PtrSize = 4


### PR DESCRIPTION
Most of malwares check open processes for anti-analysis techniques, others just use to check for processes, I wanted to have a single component to handle functions as (OpenProcess,TerminateProcess,Process32First), because handling each function on its own would have been a mess, I created the file processmanager.go, which can be seen as kernel storage for processes on the emulator. I then added the functionalities to add stub programs before starting emulation, extracted some processes from a windows used by a normal user to give an illusion of a normal machine and added them by default.
    I also wrote a simple C program to test it, its actually the same code I used to extract the processes.